### PR TITLE
-fixing an error where "src" module is not found"

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,9 +6,9 @@ author_email = tassingremi@gmail.com
 description = Library for collecting and parsing ARMP content
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/pypa/sampleproject
+url = https://github.com/2trc/armp-lib
 project_urls =
-    Bug Tracker = https://github.com/pypa/sampleproject/issues
+    Bug Tracker = https://github.com/2trc/armp-lib/issues
 classifiers =
     Programming Language :: Python :: 3
     License :: OSI Approved :: MIT License

--- a/src/armp/__init__.py
+++ b/src/armp/__init__.py
@@ -1,2 +1,2 @@
-from src.armp.tender_collector import get_next_url
-from src.armp.tender_parser import get_tous_les_avis, parse_one_avis
+from armp.tender_collector import get_next_url
+from armp.tender_parser import get_tous_les_avis, parse_one_avis


### PR DESCRIPTION
- added project url in setup.cfg
Trying to pull real Tender data from the Commands you created, I got an error related to the module "src" not found.
This pull request fixes this issue.
- One minor changes I also did is to set the real project URL in setup.cfg.

As a consequence, I was able to fetch recent Tender Data on my server.